### PR TITLE
Raid settings

### DIFF
--- a/src/callbacks/FikaRaidCallbacks.ts
+++ b/src/callbacks/FikaRaidCallbacks.ts
@@ -44,4 +44,9 @@ export class FikaRaidCallbacks {
     public handleRaidSpawnpoint(_url: string, info: IFikaRaidServerIdRequestData, _sessionID: string): string {
         return this.httpResponseUtil.noBody(this.fikaRaidController.handleRaidSpawnpoint(info));
     }
+
+    /** Handle /fika/raid/getsettings */
+    public handleRaidGetSettings(_url: string, info: IFikaRaidServerIdRequestData, _sessionID: string): string {
+        return this.httpResponseUtil.noBody(this.fikaRaidController.handleRaidGetSettings(info));
+    }
 }

--- a/src/controllers/FikaRaidController.ts
+++ b/src/controllers/FikaRaidController.ts
@@ -9,6 +9,7 @@ import { IFikaRaidJoinRequestData } from "../models/fika/routes/raid/join/IFikaR
 import { IFikaRaidJoinResponse } from "../models/fika/routes/raid/join/IFikaRaidJoinResponse";
 import { IFikaRaidLeaveRequestData } from "../models/fika/routes/raid/leave/IFikaRaidLeaveRequestData";
 import { IFikaRaidSpawnpointResponse } from "../models/fika/routes/raid/spawnpoint/IFikaRaidSpawnpointResponse";
+import { IFikaRaidSettingsResponse } from "src/models/fika/routes/raid/getsettings/IFikaRaidSettingsResponse";
 import { FikaMatchService } from "../services/FikaMatchService";
 
 @injectable()
@@ -86,6 +87,22 @@ export class FikaRaidController {
 
         return {
             spawnpoint: match.spawnPoint,
+        };
+    }
+
+    /**
+     * Handle /fika/raid/getsettings
+     * @param request
+     */
+    public handleRaidGetSettings(request: IFikaRaidServerIdRequestData): IFikaRaidSettingsResponse {
+        const match = this.fikaMatchService.getMatch(request.serverId);
+        if (!match) {
+            return;
+        }
+
+        return {
+            metabolismDisabled: match.raidConfig.metabolismDisabled,
+            playersSpawnPlace: match.raidConfig.playersSpawnPlace
         };
     }
 }

--- a/src/controllers/FikaRaidController.ts
+++ b/src/controllers/FikaRaidController.ts
@@ -9,7 +9,7 @@ import { IFikaRaidJoinRequestData } from "../models/fika/routes/raid/join/IFikaR
 import { IFikaRaidJoinResponse } from "../models/fika/routes/raid/join/IFikaRaidJoinResponse";
 import { IFikaRaidLeaveRequestData } from "../models/fika/routes/raid/leave/IFikaRaidLeaveRequestData";
 import { IFikaRaidSpawnpointResponse } from "../models/fika/routes/raid/spawnpoint/IFikaRaidSpawnpointResponse";
-import { IFikaRaidSettingsResponse } from "src/models/fika/routes/raid/getsettings/IFikaRaidSettingsResponse";
+import { IFikaRaidSettingsResponse } from "../models/fika/routes/raid/getsettings/IFikaRaidSettingsResponse";
 import { FikaMatchService } from "../services/FikaMatchService";
 
 @injectable()

--- a/src/models/fika/routes/raid/getsettings/IFikaRaidSettingsResponse.ts
+++ b/src/models/fika/routes/raid/getsettings/IFikaRaidSettingsResponse.ts
@@ -1,0 +1,4 @@
+export interface IFikaRaidSettingsResponse {
+    metabolismDisabled: boolean;
+    playersSpawnPlace: string;
+}

--- a/src/routers/static/FikaRaidStaticRouter.ts
+++ b/src/routers/static/FikaRaidStaticRouter.ts
@@ -28,6 +28,9 @@ export class FikaRaidStaticRouter extends StaticRouter {
             new RouteAction("/fika/raid/spawnpoint", (url: string, info: IFikaRaidServerIdRequestData, sessionID: string, _output: string): string => {
                 return this.fikaRaidCallbacks.handleRaidSpawnpoint(url, info, sessionID);
             }),
+            new RouteAction("/fika/raid/getsettings", (url: string, info: IFikaRaidServerIdRequestData, sessionID: string, _output: string): string => {
+                return this.fikaRaidCallbacks.handleRaidGetSettings(url, info, sessionID);
+            }),
         ]);
     }
 }


### PR DESCRIPTION
Adds the ability to retrieve raid settings for clients
Question, why is the player spawn place not an `enum`? Is this from SPT or us? In the Tarkov client it's an `enum`, but I can parse it anyway so not an issue.