### PR TITLE
package.json: Bump Fika version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "server",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "akiVersion": "3.8.3",
     "main": "src/mod.js",
     "scripts": {


### PR DESCRIPTION
Package.json for v2.1.1 doesn't have the correct version specified, resulting in it showing v2.1.0 when built.