### PR TITLE
Fix exception on raid end whenever server is restarted during gameplay

### DIFF
--- a/src/services/FikaMatchService.ts
+++ b/src/services/FikaMatchService.ts
@@ -329,6 +329,10 @@ export class FikaMatchService {
      * @param playerId
      */
     public removePlayerFromMatch(matchId: string, playerId: string): void {
+        if (!this.matches.has(matchId)) {
+            return;
+        }
+
         this.matches.get(matchId).players.delete(playerId);
     }
 }


### PR DESCRIPTION
Added a check to FikaMatchService.removePlayerFromMatch to make sure matches has the id before trying to get and mutate it. Fixes #29 