### PR TITLE
Workspace settings change

### DIFF
--- a/Fika-Server.code-workspace
+++ b/Fika-Server.code-workspace
@@ -29,7 +29,17 @@
         "window.title": "Fika Server",
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "biomejs.biome",
-        "editor.codeActionsOnSave": ["source.organizeImports.biome"]
+        "editor.codeActionsOnSave": ["source.organizeImports.biome"],
+        "files.exclude": {
+            "**/.git": true,
+            "**/.svn": true,
+            "**/.hg": true,
+            "**/CVS": true,
+            "**/.DS_Store": true,
+            "**/Thumbs.db": true,
+            "**/*.map": true,
+            "**/*.js": true
+        }
     },
     "extensions": {
         "recommendations": ["EditorConfig.EditorConfig", "biomejs.biome", "refringe.spt-id-highlighter"]


### PR DESCRIPTION
Adds eclusions to .map and .js files. These get generated when SPT server starts. It causes clutter in the file browser which makes it hard to work on when running from source. The rest were autogenerated and I was not going to argue with it.