### PR TITLE
Fixed issue #50

### DIFF
--- a/src/controllers/FikaDialogueController.ts
+++ b/src/controllers/FikaDialogueController.ts
@@ -62,8 +62,9 @@ export class FikaDialogueController {
                     Level: profile.Info.Level,
                     Side: profile.Info.Side,
                     MemberCategory: profile.Info.MemberCategory,
+                    SelectedMemberCategory: profile.Info.MemberCategory,
                 },
-            });
+            } as any);
         }
 
         return {


### PR DESCRIPTION
SelectedMemberCategory was not set as it was not part of the types provided by SPT. A PR has been made to SPT and adding this will prevent them from showing up as the default value.