### PR TITLE
Add `allowSpectateFreeCam` config option

### DIFF
--- a/assets/configs/fika.jsonc
+++ b/assets/configs/fika.jsonc
@@ -4,6 +4,7 @@
         "friendlyFire": true,
         "dynamicVExfils": false,
         "allowFreeCam": false,
+        "allowSpectateFreeCam": false,
         "allowItemSending": true,
         "blacklistedItems": [],
         "forceSaveOnDeath": false,

--- a/src/models/fika/config/IFikaConfigClient.ts
+++ b/src/models/fika/config/IFikaConfigClient.ts
@@ -3,6 +3,7 @@ export interface IFikaConfigClient {
     friendlyFire: boolean;
     dynamicVExfils: boolean;
     allowFreeCam: boolean;
+    allowSpectateFreeCam: boolean;
     allowItemSending: boolean;
     blacklistedItems: string[],
     forceSaveOnDeath: boolean;


### PR DESCRIPTION
Works in conjunction with https://github.com/project-fika/Fika-Plugin/pull/131 to allow server-side control of the spectator freecam on death/extract.