### PR TITLE
Feature: WS Notifications

### DIFF
--- a/assets/database/locales/global/en.json
+++ b/assets/database/locales/global/en.json
@@ -91,5 +91,7 @@
     "F_UI_CoopRaidSettings": "Fika Co-op Raid Settings",
     "F_UI_FikaAlwaysCoop": "Co-op is always enabled in Fika",
     "F_UI_UpnpFailed": "UPnP mapping failed. Make sure the selected port is not already open!\nDisable UPnP if you are using a VPN.",
-    "F_UI_InitWeather": "Generating weather..."
+    "F_UI_InitWeather": "Generating weather...",
+    "F_Notification_RaidStarted": "{0} started a raid on {1}",
+    "F_Notification_ItemReceived": "You received a {0} from {1}"
 }

--- a/src/callbacks/FikaNotificationCallbacks.ts
+++ b/src/callbacks/FikaNotificationCallbacks.ts
@@ -1,0 +1,47 @@
+import { inject, injectable } from "tsyringe";
+
+import { HttpResponseUtil } from "@spt/utils/HttpResponseUtil";
+
+import { IPushNotification } from "../models/fika/websocket/notifications/IPushNotification";
+import { FikaNotificationWebSocket } from "../websockets/FikaNotificationWebSocket";
+import { INullResponseData } from "@spt/models/eft/httpResponse/INullResponseData";
+import { FikaNotifications } from "../models/enums/FikaNotifications";
+import { EFTNotificationIconType } from "../models/enums/EFTNotificationIconType";
+
+@injectable()
+export class FikaNotificationCallbacks {
+    constructor(
+        @inject("HttpResponseUtil") protected httpResponseUtil: HttpResponseUtil,
+        @inject("FikaNotificationWebSocket") protected fikaNotificationWebSocket: FikaNotificationWebSocket,
+    ) {
+        // empty
+    }
+
+    /** Handle /fika/notification/push */
+    public handlePushNotification(_url: string, info: IPushNotification, _sessionID: string): INullResponseData {
+        // Yes, technically this needs a controller to fit into this format. But I cant be bothered setting up a whole controller for a few checks.
+        if (!info.notification)
+        {
+            return this.httpResponseUtil.nullResponse();
+        }
+        
+
+        info.type = FikaNotifications.PushNotification;
+
+        // Set default notification icon if data for this has not been correctly given.
+        if (!info.notificationIcon || typeof(info.notificationIcon) != 'number')
+        {
+            info.notificationIcon = EFTNotificationIconType.Default;
+        }
+
+        //Do some exception handling for the client, icon 6 seems to cause an exception as well as going out of the enum's bounds.
+        if (info.notificationIcon == 6 || info.notificationIcon > 14)
+        {
+            info.notificationIcon = EFTNotificationIconType.Default;
+        }
+
+        this.fikaNotificationWebSocket.broadcast(info);
+
+        return this.httpResponseUtil.nullResponse();
+    }
+}

--- a/src/callbacks/FikaNotificationCallbacks.ts
+++ b/src/callbacks/FikaNotificationCallbacks.ts
@@ -25,7 +25,6 @@ export class FikaNotificationCallbacks {
             return this.httpResponseUtil.nullResponse();
         }
         
-
         info.type = FikaNotifications.PushNotification;
 
         // Set default notification icon if data for this has not been correctly given.

--- a/src/controllers/FikaRaidController.ts
+++ b/src/controllers/FikaRaidController.ts
@@ -25,6 +25,9 @@ import { IFikaRaidLeaveRequestData } from "../models/fika/routes/raid/leave/IFik
 import { FikaMatchService } from "../services/FikaMatchService";
 import { FikaDedicatedRaidService } from "../services/dedicated/FikaDedicatedRaidService";
 import { FikaDedicatedRaidWebSocket } from "../websockets/FikaDedicatedRaidWebSocket";
+import { FikaNotificationWebSocket } from "../websockets/FikaNotificationWebSocket";
+import { IStartRaidNotification } from "../models/fika/websocket/notifications/IStartRaidNotification";
+import { FikaNotifications } from "../models/enums/FikaNotifications";
 
 @injectable()
 export class FikaRaidController {
@@ -35,6 +38,7 @@ export class FikaRaidController {
         @inject("ProfileHelper") protected profileHelper: ProfileHelper,
         @inject("WinstonLogger") protected logger: ILogger,
         @inject("InraidController") protected inraidController: InraidController
+        @inject("FikaNotificationWebSocket") protected fikaNotificationWebSocket: FikaNotificationWebSocket,
     ) {
         // empty
     }
@@ -44,6 +48,14 @@ export class FikaRaidController {
      * @param request
      */
     public handleRaidCreate(request: IFikaRaidCreateRequestData): IFikaRaidCreateResponse {
+        const notification = {
+            type: FikaNotifications.StartedRaid,
+            nickname: request.hostUsername,
+            location: request.settings.location
+        } as IStartRaidNotification;
+
+        this.fikaNotificationWebSocket.broadcast(notification);
+
         return {
             success: this.fikaMatchService.createMatch(request),
         };

--- a/src/controllers/FikaRaidController.ts
+++ b/src/controllers/FikaRaidController.ts
@@ -51,7 +51,7 @@ export class FikaRaidController {
         const notification = {
             type: FikaNotifications.StartedRaid,
             nickname: request.hostUsername,
-            location: request.settings.location
+            location: request.settings.location // Todo: Location needs to be localized, currently it send the format as "bigmap" or "rezervbase"
         } as IStartRaidNotification;
 
         this.fikaNotificationWebSocket.broadcast(notification);

--- a/src/controllers/FikaRaidController.ts
+++ b/src/controllers/FikaRaidController.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "tsyringe";
 import { WebSocket } from "ws";
 
+import { DatabaseService } from "@spt/services/DatabaseService";
 import { InraidController } from "@spt/controllers/InraidController";
 import { ProfileHelper } from "@spt/helpers/ProfileHelper";
 import { IPmcData } from "@spt/models/eft/common/IPmcData";
@@ -32,12 +33,13 @@ import { FikaNotifications } from "../models/enums/FikaNotifications";
 @injectable()
 export class FikaRaidController {
     constructor(
+        @inject("DatabaseService") protected databaseService: DatabaseService,
         @inject("FikaMatchService") protected fikaMatchService: FikaMatchService,
         @inject("FikaDedicatedRaidService") protected fikaDedicatedRaidService: FikaDedicatedRaidService,
         @inject("FikaDedicatedRaidWebSocket") protected fikaDedicatedRaidWebSocket: FikaDedicatedRaidWebSocket,
         @inject("ProfileHelper") protected profileHelper: ProfileHelper,
         @inject("WinstonLogger") protected logger: ILogger,
-        @inject("InraidController") protected inraidController: InraidController
+        @inject("InraidController") protected inraidController: InraidController,
         @inject("FikaNotificationWebSocket") protected fikaNotificationWebSocket: FikaNotificationWebSocket,
     ) {
         // empty
@@ -48,10 +50,12 @@ export class FikaRaidController {
      * @param request
      */
     public handleRaidCreate(request: IFikaRaidCreateRequestData): IFikaRaidCreateResponse {
+        const globalLocales = this.databaseService.getLocales().global.en;
+
         const notification = {
             type: FikaNotifications.StartedRaid,
             nickname: request.hostUsername,
-            location: request.settings.location // Todo: Location needs to be localized, currently it send the format as "bigmap" or "rezervbase"
+            location:  globalLocales[request.settings.location]
         } as IStartRaidNotification;
 
         this.fikaNotificationWebSocket.broadcast(notification);

--- a/src/controllers/FikaSendItemController.ts
+++ b/src/controllers/FikaSendItemController.ts
@@ -9,6 +9,7 @@ import { ISptProfile } from "@spt/models/eft/profile/ISptProfile";
 import { ILogger } from "@spt/models/spt/utils/ILogger";
 import { EventOutputHolder } from "@spt/routers/EventOutputHolder";
 import { SaveServer } from "@spt/servers/SaveServer";
+import { DatabaseService } from "@spt/services/DatabaseService";
 import { MailSendService } from "@spt/services/MailSendService";
 import { HttpResponseUtil } from "@spt/utils/HttpResponseUtil";
 
@@ -24,6 +25,7 @@ export class FikaSendItemController {
     constructor(
         @inject("WinstonLogger") protected logger: ILogger,
         @inject("EventOutputHolder") protected eventOutputHolder: EventOutputHolder,
+        @inject("DatabaseService") protected databaseService: DatabaseService,
         @inject("MailSendService") protected mailSendService: MailSendService,
         @inject("InventoryHelper") protected inventoryHelper: InventoryHelper,
         @inject("SaveServer") protected saveServer: SaveServer,
@@ -87,11 +89,13 @@ export class FikaSendItemController {
 
         this.inventoryHelper.removeItem(senderProfile.characters.pmc, body.id, sessionID, output);
 
+        const globalLocales = this.databaseService.getLocales().global.en;
+
         const notification = {
             type: FikaNotifications.SentItem,
             nickname: senderProfile?.characters?.pmc?.Info?.Nickname,
             targetId : body.target,
-            itemName: "An item" // Todo: This needs to have the item name localized.
+            itemName: globalLocales[`${itemsToSend[0]._tpl} Name`]
         } as IReceivedSentItemNotification;
 
         this.fikaNotificationWebSocket.broadcast(notification);

--- a/src/controllers/FikaSendItemController.ts
+++ b/src/controllers/FikaSendItemController.ts
@@ -15,6 +15,9 @@ import { HttpResponseUtil } from "@spt/utils/HttpResponseUtil";
 import { IFikaSendItemRequestData } from "../models/fika/routes/senditem/IFikaSendItemRequestData";
 import { IFikaSenditemAvailablereceiversResponse } from "../models/fika/routes/senditem/availablereceivers/IFikaSenditemAvailablereceiversResponse";
 import { FikaConfig } from "../utils/FikaConfig";
+import { FikaNotificationWebSocket } from "../websockets/FikaNotificationWebSocket";
+import { IReceivedSentItemNotification } from "../models/fika/websocket/notifications/IReceivedSentItemNotification";
+import { FikaNotifications } from "../models/enums/FikaNotifications";
 
 @injectable()
 export class FikaSendItemController {
@@ -27,6 +30,7 @@ export class FikaSendItemController {
         @inject("ItemHelper") protected itemHelper: ItemHelper,
         @inject("HttpResponseUtil") protected httpResponse: HttpResponseUtil,
         @inject("FikaConfig") protected fikaConfig: FikaConfig,
+        @inject("FikaNotificationWebSocket") protected fikaNotificationWebSocket: FikaNotificationWebSocket
     ) {
         // empty
     }
@@ -82,6 +86,15 @@ export class FikaSendItemController {
         );
 
         this.inventoryHelper.removeItem(senderProfile.characters.pmc, body.id, sessionID, output);
+
+        const notification = {
+            type: FikaNotifications.SentItem,
+            nickname: senderProfile?.characters?.pmc?.Info?.Nickname,
+            targetId : body.target,
+            itemName: "An item" // Todo: This needs to have the item name localized.
+        } as IReceivedSentItemNotification;
+
+        this.fikaNotificationWebSocket.broadcast(notification);
 
         return output;
     }

--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -45,10 +45,13 @@ import { FikaSendItemStaticRouter } from "../routers/static/FikaSendItemStaticRo
 import { FikaUpdateStaticRouter } from "../routers/static/FikaUpdateStaticRouter";
 
 import { FikaDedicatedRaidWebSocket } from "../websockets/FikaDedicatedRaidWebSocket";
+import { FikaNotificationWebSocket } from "../websockets/FikaNotificationWebSocket";
 
 import { Fika } from "../Fika";
 import { FikaDedicatedProfileService } from "../services/dedicated/FikaDedicatedProfileService";
 import { FikaServerTools } from "../utils/FikaServerTools";
+import { FikaNotificationStaticRouter } from "../routers/static/FikaNotificationStaticRouter";
+import { FikaNotificationCallbacks } from "../callbacks/FikaNotificationCallbacks";
 
 export class Container {
     public static register(container: DependencyContainer): void {
@@ -89,9 +92,12 @@ export class Container {
         container.registerType("StaticRoutes", "FikaRaidStaticRouter");
         container.registerType("StaticRoutes", "FikaSendItemStaticRouter");
         container.registerType("StaticRoutes", "FikaUpdateStaticRouter");
+        container.registerType("StaticRoutes", "FikaNotificationStaticRouter");
 
         container.registerType("IERouters", "FikaItemEventRouter");
+        
         container.registerType("WebSocketConnectionHandler", "FikaDedicatedRaidWebSocket");
+        container.registerType("WebSocketConnectionHandler", "FikaNotificationWebSocket");
     }
 
     private static registerUtils(container: DependencyContainer): void {
@@ -143,6 +149,7 @@ export class Container {
         container.register<FikaRaidCallbacks>("FikaRaidCallbacks", { useClass: FikaRaidCallbacks });
         container.register<FikaSendItemCallbacks>("FikaSendItemCallbacks", { useClass: FikaSendItemCallbacks });
         container.register<FikaUpdateCallbacks>("FikaUpdateCallbacks", { useClass: FikaUpdateCallbacks });
+        container.register<FikaNotificationCallbacks>("FikaNotificationCallbacks", { useClass: FikaNotificationCallbacks });
     }
 
     private static registerRouters(container: DependencyContainer): void {
@@ -152,9 +159,11 @@ export class Container {
         container.register<FikaSendItemStaticRouter>("FikaSendItemStaticRouter", { useClass: FikaSendItemStaticRouter });
         container.register<FikaUpdateStaticRouter>("FikaUpdateStaticRouter", { useClass: FikaUpdateStaticRouter });
         container.register<FikaItemEventRouter>("FikaItemEventRouter", { useClass: FikaItemEventRouter });
+        container.register<FikaNotificationStaticRouter>("FikaNotificationStaticRouter", { useClass: FikaNotificationStaticRouter });
     }
 
     private static registerWebSockets(container: DependencyContainer): void {
         container.register<FikaDedicatedRaidWebSocket>("FikaDedicatedRaidWebSocket", FikaDedicatedRaidWebSocket, { lifecycle: Lifecycle.Singleton });
+        container.register<FikaNotificationWebSocket>("FikaNotificationWebSocket", FikaNotificationWebSocket, { lifecycle: Lifecycle.Singleton });
     }
 }

--- a/src/models/enums/EFTNotificationIconType.ts
+++ b/src/models/enums/EFTNotificationIconType.ts
@@ -1,0 +1,17 @@
+export enum EFTNotificationIconType {
+    Default = 0,
+    Alert = 1,
+    Friend = 2,
+    Mail = 3,
+    Note = 4,
+    Quest = 5,
+    Achievement = 6, // This one is broken.
+    EntryPoint = 7,
+    RagFair = 8,
+    Hideout = 9,
+    WishlistQuest = 10,
+    WishlistHideout = 11,
+    WishlistTrading = 12,
+    WishlistEquipment = 13,
+    WishlistOther = 14
+}

--- a/src/models/enums/FikaNotifications.ts
+++ b/src/models/enums/FikaNotifications.ts
@@ -1,0 +1,6 @@
+export enum FikaNotifications {
+    KeepAlive = 0,
+    StartedRaid = 1,
+    SentItem = 2,
+    PushNotification = 3
+}

--- a/src/models/fika/websocket/IFikaNotificationBase.ts
+++ b/src/models/fika/websocket/IFikaNotificationBase.ts
@@ -1,0 +1,5 @@
+import { FikaNotifications } from "../../enums/FikaNotifications";
+
+export interface IFikaNotificationBase {
+    type: FikaNotifications;
+}

--- a/src/models/fika/websocket/notifications/IPushNotification.ts
+++ b/src/models/fika/websocket/notifications/IPushNotification.ts
@@ -1,0 +1,7 @@
+import { IFikaNotificationBase } from "../IFikaNotificationBase";
+import { EFTNotificationIconType } from "../../../enums/EFTNotificationIconType";
+
+export interface IPushNotification extends IFikaNotificationBase {
+    notificationIcon : EFTNotificationIconType;
+    notification: string;
+}

--- a/src/models/fika/websocket/notifications/IReceivedSentItemNotification.ts
+++ b/src/models/fika/websocket/notifications/IReceivedSentItemNotification.ts
@@ -1,0 +1,7 @@
+import { IFikaNotificationBase } from "../IFikaNotificationBase";
+
+export interface IReceivedSentItemNotification extends IFikaNotificationBase {
+    nickname: string;
+    targetId: string;
+    itemName: string;
+}

--- a/src/models/fika/websocket/notifications/IStartRaidNotification.ts
+++ b/src/models/fika/websocket/notifications/IStartRaidNotification.ts
@@ -1,0 +1,6 @@
+import { IFikaNotificationBase } from "../IFikaNotificationBase";
+
+export interface IStartRaidNotification extends IFikaNotificationBase {
+    nickname: string;
+    location: string;
+}

--- a/src/routers/static/FikaNotificationStaticRouter.ts
+++ b/src/routers/static/FikaNotificationStaticRouter.ts
@@ -1,0 +1,17 @@
+import { inject, injectable } from "tsyringe";
+
+import { RouteAction, StaticRouter } from "@spt/di/Router";
+
+import { FikaNotificationCallbacks } from "../../callbacks/FikaNotificationCallbacks";
+import { IPushNotification } from "../../models/fika/websocket/notifications/IPushNotification";
+
+@injectable()
+export class FikaNotificationStaticRouter extends StaticRouter {
+    constructor(@inject("FikaNotificationCallbacks") protected fikaNotificationCallbacks: FikaNotificationCallbacks) {
+        super([
+            new RouteAction("/fika/notification/push", async (url: string, info: IPushNotification, sessionID: string, _output: string): Promise<any> => {
+                return this.fikaNotificationCallbacks.handlePushNotification(url, info, sessionID);
+            })
+        ]);
+    }
+}

--- a/src/websockets/FikaNotificationWebSocket.ts
+++ b/src/websockets/FikaNotificationWebSocket.ts
@@ -37,7 +37,7 @@ export class FikaNotificationWebSocket implements IWebSocketConnectionHandler {
 
         this.logger.debug(`[${this.getSocketId()}] User is ${UserSessionID}`);
 
-        if(!this.saveServer.getProfile(UserSessionID))
+        if (!this.saveServer.getProfile(UserSessionID))
         {
             this.logger.warning(`[${this.getSocketId()}] Invalid user ${UserSessionID} tried to authenticate!`);
             return;
@@ -69,7 +69,7 @@ export class FikaNotificationWebSocket implements IWebSocketConnectionHandler {
         {
             const clientWebSocket = this.clientWebSockets[client];
 
-            if(clientWebSocket.readyState == WebSocket.CLOSED) {
+            if (clientWebSocket.readyState == WebSocket.CLOSED) {
                 continue;
             }
 
@@ -81,7 +81,7 @@ export class FikaNotificationWebSocket implements IWebSocketConnectionHandler {
         for (const sessionId in this.clientWebSockets) {
             const clientWebSocket = this.clientWebSockets[sessionId];
 
-            if(clientWebSocket.readyState == WebSocket.CLOSED) {
+            if (clientWebSocket.readyState == WebSocket.CLOSED) {
                 continue;
             }
 

--- a/src/websockets/FikaNotificationWebSocket.ts
+++ b/src/websockets/FikaNotificationWebSocket.ts
@@ -32,7 +32,7 @@ export class FikaNotificationWebSocket implements IWebSocketConnectionHandler {
     }
 
     public onConnection(ws: WebSocket, req: IncomingMessage): void {
-        if (!req.headers.authorization)
+        if (req.headers.authorization === undefined)
         {
             ws.close();
             return;

--- a/src/websockets/FikaNotificationWebSocket.ts
+++ b/src/websockets/FikaNotificationWebSocket.ts
@@ -32,6 +32,12 @@ export class FikaNotificationWebSocket implements IWebSocketConnectionHandler {
     }
 
     public onConnection(ws: WebSocket, req: IncomingMessage): void {
+        if (!req.headers.authorization)
+        {
+            ws.close();
+            return;
+        }
+
         const Authorization = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString().split(":");
         const UserSessionID = Authorization[0];
 

--- a/src/websockets/FikaNotificationWebSocket.ts
+++ b/src/websockets/FikaNotificationWebSocket.ts
@@ -1,0 +1,96 @@
+import { ILogger } from "@spt/models/spt/utils/ILogger";
+import { inject, injectable } from "tsyringe";
+import { IWebSocketConnectionHandler } from "@spt/servers/ws/IWebSocketConnectionHandler";
+import { IncomingMessage } from "http";
+import { WebSocket } from "ws";
+import { FikaNotifications } from "../models/enums/FikaNotifications";
+import { IFikaNotificationBase } from "../models/fika/websocket/IFikaNotificationBase";
+import { SaveServer } from "@spt/servers/SaveServer";
+
+@injectable()
+export class FikaNotificationWebSocket implements IWebSocketConnectionHandler {
+    public clientWebSockets: Record<string, WebSocket>;
+
+    constructor(
+        @inject("SaveServer") protected saveServer: SaveServer,
+        @inject("WinstonLogger") protected logger: ILogger,
+    ) {
+        this.clientWebSockets = {};
+
+        // Keep websocket connections alive
+        setInterval(() => {
+            this.keepWebSocketAlive();
+        }, 30000);
+    }
+
+    public getSocketId(): string {
+        return "Fika Notification Manager";
+    }
+
+    public getHookUrl(): string {
+        return "/fika/notification/";
+    }
+
+    public onConnection(ws: WebSocket, req: IncomingMessage): void {
+        const Authorization = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString().split(":");
+        const UserSessionID = Authorization[0];
+
+        this.logger.debug(`[${this.getSocketId()}] User is ${UserSessionID}`);
+
+        if(!this.saveServer.getProfile(UserSessionID))
+        {
+            this.logger.warning(`[${this.getSocketId()}] Invalid user ${UserSessionID} tried to authenticate!`);
+            return;
+        }
+
+        this.clientWebSockets[UserSessionID] = ws;
+
+        ws.on("message", (msg) => this.onMessage(UserSessionID, msg.toString()));
+        ws.on("close", (code, reason) => this.onClose(ws, UserSessionID, code, reason));
+    }
+
+    public onMessage(sessionID: string, msg: string): void {
+        // Do nothing
+    }
+
+    public onClose(ws: WebSocket, sessionID: string,  code: number, reason: Buffer): void {
+        const clientWebSocket = this.clientWebSockets[sessionID];
+
+        if (clientWebSocket === ws)
+        {
+            this.logger.debug(`[${this.getSocketId()}] Deleting client ${sessionID}`);
+
+            delete this.clientWebSockets[sessionID];
+        }
+    }
+
+    public broadcast(message: IFikaNotificationBase): void {
+        for (const client in this.clientWebSockets)
+        {
+            const clientWebSocket = this.clientWebSockets[client];
+
+            if(clientWebSocket.readyState == WebSocket.CLOSED) {
+                continue;
+            }
+
+            clientWebSocket.send(JSON.stringify(message));
+        }
+    }
+
+    public keepWebSocketAlive(): void {
+        for (const sessionId in this.clientWebSockets) {
+            const clientWebSocket = this.clientWebSockets[sessionId];
+
+            if(clientWebSocket.readyState == WebSocket.CLOSED) {
+                continue;
+            }
+
+            // Send a keep alive message to clients.
+            clientWebSocket.send(
+                JSON.stringify({
+                    type: FikaNotifications.KeepAlive
+                }),
+            );
+        }
+    }
+}


### PR DESCRIPTION
Adds WebSocket notifications ( Closes: #61 )

Currently supports 3 notifications:
* Push notifications
* Host going in to raid notification
* Notification upon receiving an item

The push notification can only be triggered from a HTTP endpoint at this point, I don't currently see a need to add the functionality to anything else (But it is possible!)

The push notification can be triggered with the following code in PowerShell: `Invoke-WebRequest -Headers @{"requestcompressed"="0"} -Method "POST" http://127.0.0.1:6969/fika/notification/push -Body '{"notification": "Hello Shynd", "notificationIcon": 0}'`

Where `notification` can be anything in a string format, and `notificationIcon` can be any number within this enum: https://github.com/project-fika/Fika-Server/blob/6f09c2dd5a30cca96518e3183d1737c87c99f548/src/models/enums/EFTNotificationIconType.ts#L1-L17