### PR TITLE
Directly reference equipment ID when viewing another player's profile

### DIFF
--- a/src/overrides/controllers/ProfileController.ts
+++ b/src/overrides/controllers/ProfileController.ts
@@ -98,8 +98,7 @@ export class ProfileControllerOverride extends Override {
                         },
                         skills: playerPmc.Skills,
                         equipment: {
-                            // Default inventory tpl
-                            Id: playerPmc.Inventory.items.find((x) => x._tpl === "55d7217a4bdc2d86028b456d")._id,
+                            Id: playerPmc.Inventory.equipment,
                             Items: playerPmc.Inventory.items,
                         },
                         achievements: playerPmc.Achievements,


### PR DESCRIPTION
This fixes an edge-case where the `.find` could return a gear rack mannequin's equipment instead of the player's if their inventory isn't in the order expected.