### PR TITLE
Revert removal of HttpRouter override

### DIFF
--- a/src/di/Container.ts
+++ b/src/di/Container.ts
@@ -8,6 +8,7 @@ import { AchievementControllerOverride } from "../overrides/controllers/Achievem
 import { DialogueControllerOverride } from "../overrides/controllers/DialogueController";
 import { ProfileControllerOverride } from "../overrides/controllers/ProfileController";
 // import { LocalesOverride } from "../overrides/other/Locales";
+import { HttpRouterOverride } from "../overrides/routers/HttpRouter";
 import { LocationLifecycleServiceOverride } from "../overrides/services/LocationLifecycleService";
 
 import { FikaInsuranceService } from "../services/FikaInsuranceService";
@@ -83,6 +84,7 @@ export class Container {
         container.registerType("Overrides", "DialogueCallbacksOverride");
         container.registerType("Overrides", "DialogueControllerOverride");
         container.registerType("Overrides", "ProfileControllerOverride");
+        container.registerType("Overrides", "HttpRouterOverride");
         // container.registerType("Overrides", "LocalesOverride");
         container.registerType("Overrides", "AchievementControllerOverride");
         container.registerType("Overrides", "LocationLifecycleServiceOverride");
@@ -111,6 +113,7 @@ export class Container {
         container.register<DialogueCallbacksOverride>("DialogueCallbacksOverride", DialogueCallbacksOverride, { lifecycle: Lifecycle.Singleton });
         container.register<DialogueControllerOverride>("DialogueControllerOverride", DialogueControllerOverride, { lifecycle: Lifecycle.Singleton });
         container.register<ProfileControllerOverride>("ProfileControllerOverride", ProfileControllerOverride, { lifecycle: Lifecycle.Singleton });
+        container.register<HttpRouterOverride>("HttpRouterOverride", HttpRouterOverride, { lifecycle: Lifecycle.Singleton });
         // container.register<LocalesOverride>("LocalesOverride", LocalesOverride, { lifecycle: Lifecycle.Singleton });
         container.register<Overrider>("Overrider", Overrider, { lifecycle: Lifecycle.Singleton });
         container.register<AchievementControllerOverride>("AchievementControllerOverride", AchievementControllerOverride, { lifecycle: Lifecycle.Singleton });

--- a/src/overrides/routers/HttpRouter.ts
+++ b/src/overrides/routers/HttpRouter.ts
@@ -1,0 +1,38 @@
+import { IncomingMessage } from "node:http";
+import { DependencyContainer, inject, injectable } from "tsyringe";
+
+import { HttpServerHelper } from "@spt/helpers/HttpServerHelper";
+import { HttpRouter } from "@spt/routers/HttpRouter";
+
+import { Override } from "../../di/Override";
+
+// Thanks to DrakiaXYZ for this implementation
+
+@injectable()
+export class HttpRouterOverride extends Override {
+    constructor(@inject("HttpServerHelper") protected httpServerHelper: HttpServerHelper) {
+        super();
+    }
+
+    public execute(container: DependencyContainer): void {
+        // We need access to the full `req` object, so we need to hijack the getResponse method
+        container.afterResolution(
+            "HttpRouter",
+            (_, result: HttpRouter) => {
+                const originalGetResponse = result.getResponse;
+
+                result.getResponse = async (req: IncomingMessage, info: any, sessionID: string): Promise<string> => {
+                    let response = (await originalGetResponse.apply(result, [req, info, sessionID])) as string;
+
+                    // if the response contains host, replace host with ours
+                    if (req.headers?.host) {
+                        response = response.replaceAll(this.httpServerHelper.buildUrl(), req.headers.host);
+                    }
+
+                    return response;
+                };
+            },
+            { frequency: "Always" },
+        );
+    }
+}


### PR DESCRIPTION
## Description
This reverts commit b4ad3a4d8f13bd8c4771fb0c7e219d950c47de75, which removed the HttpRouter override that replaced the backend URL with the value in the request's `Host` header. This was essential to get remote hosting the SPT server working for certain setups, such as:
- `backendIp` set to `0.0.0.0` in SPT's `http.json` config file, to allow listening on all available interfaces
- Containerized deployments, where the application does not have full access to the host interfaces or the external facing port from the container is mapped to a different port on the host e.g. `9999 -> 6969`

Without this router override, the SPT server returns a backend URL constructed from the backendIp and backendPort in the `http.json` config.

### SPT Server 3.11 - bac5c97ba5c54db457be3dbe00573bf99782ad3d
```bash
$ http -vvv --verify=no https://localhost:9969/client/game/mode 'responsecompressed:0'
GET /client/game/mode HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, zstd
Connection: keep-alive
Host: localhost:9969
User-Agent: HTTPie/3.2.4
responsecompressed: 0


HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: application/json
Date: Wed, 05 Mar 2025 05:16:25 GMT
Keep-Alive: timeout=5
Set-Cookie: PHPSESSID=undefined
Transfer-Encoding: chunked

{
    "data": {
        "backendUrl": "https://0.0.0.0:6969",
        "gameMode": "pve"
    },
    "err": 0
}

```

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have thoroughly tested the code changes